### PR TITLE
Make random port clearer

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -153,7 +153,7 @@ export function startServer() {
   server.listen(0, () => {
     //@ts-expect-error
     port = server?.address()?.port;
-    console.log("Server started on port", port);
+    console.log("Server started");
   });
 }
 


### PR DESCRIPTION
The extension already picks a random port. However, setting the port to a specific
value gives a different impression. This unsets that default value. It also logs
the port chosen to the console (which is not normally visible).﻿
