### PR TITLE
Only show menu for json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       ],
       "explorer/context": [
         {
-          "command": "grafana-vscode.openUrl"
+          "command": "grafana-vscode.openUrl",
+          "when": "resourceExtname == .json"
         }
       ]
     },


### PR DESCRIPTION
Currently the context menu ("Edit in Grafana") shows for all files regardless of file type. This PR causes it to only show when right clicking on json files.