### PR TITLE
Report blank url/token to user

### DIFF
--- a/public/error.html
+++ b/public/error.html
@@ -3,6 +3,6 @@ h1, p {
     color: white;
 }
 </style>
-<h1>A problem occurred connecting to Grafana</h1><p>${error}</p>
+<h1>A problem occurred connecting to Grafana</h1>${error}
 <p><button onclick="location.reload()">refresh</button></p>
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,16 +86,23 @@ export async function startServer(secrets: vscode.SecretStorage, extensionPath: 
       });
       res.write(resp.data);
     } catch (e) {
-      if (axios.isAxiosError(e)) {
+    let msg = "";
+    if (URL === "") {
+      msg += "<p><b>Error:</b> URL is not defined</p>";
+    }
+    if (token === "") {
+      msg += "<p><b>Warning:</b> No service account token specified.</p>";
+    }
+    if (axios.isAxiosError(e)) {
         if (e.response?.status === 302) {
-          sendErrorPage(res, "Authentication error");
+          sendErrorPage(res, msg+ "<p>Authentication error</p>");
         } else {
-          sendErrorPage(res, e.message);
+          sendErrorPage(res, msg + `<p>${e.message}</p>`);
         }
       } else if (e instanceof Error) {
-        sendErrorPage(res, e.message);
+        sendErrorPage(res, msg + `<p>${e.message}</p>`);
       } else {
-        sendErrorPage(res, String(e));
+        sendErrorPage(res, msg + "<p>" + String(e) + "</p>");
       }
     }
   });


### PR DESCRIPTION
This PR extends the error handling code to add reporting that either the URL is empty (an error condition) or the token is empty (a warning condition, as it *could* be an unauthenticated Grafana instance).

Here's an example of how this can look:

![image](https://github.com/grafana/grafana-vs-code-extension/assets/42545407/3f053614-d95c-489b-aea8-3b003b8e79d8)

Note, style-wise this is exactly the same as the existing UX for errors, it just adds the "warning" line,