### PR TITLE
Support VSCodium

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Grafana",
   "description": "Grafana Editor",
   "icon": "public/grafana_icon.png",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "Apache-2.0",
   "repository": {
 		"type": "git",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,8 @@ export function detectRequestSource(
 ) {
   const userAgent = req.headers["user-agent"];
 
-  if (userAgent?.includes("Code") && userAgent?.includes("Electron")) {
+  if ((userAgent?.includes("Code") || userAgent?.includes("code"))
+      && userAgent?.includes("Electron")) {
     next();
   } else {
     res.status(403).send("Access Denied");


### PR DESCRIPTION
Amongst other security protections, this extension limits use to a specific user agent. This being an example of the user agent string for VSCode itself:
```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.83.1 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36
```

However, it turns out there is a pure OSS version of VSCode, [VSCodium](https://vscodium.com/). It looks like this valid user agent may have come from VSCodium:
```
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) code-oss/1.83.0 Chrome/114.0.5735.289 Electron/25.9.0 Safari/537.36
```
This PR makes both UA strings work.