### PR TITLE
Fix for Windows use

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,9 +20,7 @@ export async function activate(ctx: vscode.ExtensionContext) {
       (uri: vscode.Uri) => {
         vscode.commands.executeCommand(
           "vscode.openWith",
-          uri.with({
-            path: uri?.fsPath,
-          }),
+          uri,
           GrafanaEditorProvider.viewType,
         );
       }),


### PR DESCRIPTION
Turns out the `uri.with()` functionality broke Windows use. I believe this fixes it. Further testing appreciated.﻿
