### PR TITLE
Remove kiosk mode

### DIFF
--- a/public/webview.html
+++ b/public/webview.html
@@ -1,7 +1,7 @@
 <html style="height: 100%;">
 <body style="height: 100%;">
 <iframe frameborder="0" id="grafana-frame"
-        src="http://localhost:${port}/d/${uid}/dashboard?serverPort=${port}&filename=${filename}&editor=${editor}&kiosk=tv"
+        src="http://localhost:${port}/d/${uid}/dashboard?serverPort=${port}&filename=${filename}&editor=${editor}"
         sandbox="allow-same-origin allow-scripts allow-popups allow-forms" width="100%" height="100%"></iframe>
 </body>
 </html>


### PR DESCRIPTION
Setting `kiosk=tv` on the URL hides some unnecessary UI (Grafana Logo, search box). However, it
also hides the `add` button, preventing us from adding new panels, which is a definite failing.
Better to have the excess UI than to lack "add".﻿
