### PR TITLE
Follow vscode theme in Grafana

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,17 @@
           "markdownDescription": "A service account token for your Grafana instance. Click the link below to add this to secure storage.\n\n[Set your token, securely](command:grafana-vscode.setPassword)",
           "order": 2
         },
+        "grafana-vscode.theme": {
+          "type": "string",
+          "default": "inherit",
+          "enum": ["inherit", "fixed", "dark", "light"],
+          "enumDescriptions": [
+            "Inherit Grafana theme from VSCode",
+            "Use Grafana's own default theme",
+            "Use dark Grafana theme",
+            "Use light Grafana theme"
+          ]
+        },
         "grafana-vscode.telemetry": {
           "type": "boolean",
           "default": true,

--- a/public/error.html
+++ b/public/error.html
@@ -1,8 +1,25 @@
-<style>
+<script>
+function style(foreground, background) {
+    document.write(`
+    <style>
+body {
+background-color: ${background}
+}
 h1, p {
-    color: white;
+color: ${foreground};
 }
 </style>
+`)
+}
+const queryParams = window.location.search.substr(1);
+if (queryParams.includes("theme=dark")) {
+    style("white", "black");
+} else if (queryParams.includes("theme=light")) {
+    style("black", "white");
+} else {
+    style("dark-gray", "light-gray");
+}
+</script>
 <h1>A problem occurred connecting to Grafana</h1>${error}
 <p><button onclick="location.reload()">refresh</button></p>
 

--- a/public/webview.html
+++ b/public/webview.html
@@ -1,7 +1,7 @@
 <html style="height: 100%;">
 <body style="height: 100%;">
 <iframe frameborder="0" id="grafana-frame"
-        src="http://localhost:${port}/d/${uid}/dashboard?theme=${theme}&serverPort=${port}&filename=${filename}&editor=${editor}"
+        src="http://localhost:${port}/d/${uid}/dashboard?${theme}serverPort=${port}&filename=${filename}&editor=${editor}"
         sandbox="allow-same-origin allow-scripts allow-popups allow-forms" width="100%" height="100%"></iframe>
 </body>
 </html>

--- a/public/webview.html
+++ b/public/webview.html
@@ -1,7 +1,7 @@
 <html style="height: 100%;">
 <body style="height: 100%;">
 <iframe frameborder="0" id="grafana-frame"
-        src="http://localhost:${port}/d/${uid}/dashboard?serverPort=${port}&filename=${filename}&editor=${editor}"
+        src="http://localhost:${port}/d/${uid}/dashboard?theme=${theme}&serverPort=${port}&filename=${filename}&editor=${editor}"
         sandbox="allow-same-origin allow-scripts allow-popups allow-forms" width="100%" height="100%"></iframe>
 </body>
 </html>

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -46,11 +46,21 @@ export class GrafanaEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   private getTheme(): string {
+
+    const settings = vscode.workspace.getConfiguration("grafana-vscode");
+    const theme = settings.get<string>("theme");
+    if (theme === "dark" || theme === "light") {
+      return `theme=${theme}&`;
+    }
+    if (theme === "fixed") {
+      return "";
+    }
+
     const kind = vscode.window.activeColorTheme.kind;
     if (kind === vscode.ColorThemeKind.Light || kind === vscode.ColorThemeKind.HighContrastLight) {
-      return "light";
+      return "theme=light&";
     } else {
-      return "dark";
+      return "theme=dark&";
     }
   }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -45,18 +45,30 @@ export class GrafanaEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.webview.html = this.getHtmlForWebview(document);
   }
 
+  private getTheme(): string {
+    const kind = vscode.window.activeColorTheme.kind;
+    if (kind === vscode.ColorThemeKind.Light || kind === vscode.ColorThemeKind.HighContrastLight) {
+      return "light";
+    } else {
+      return "dark";
+    }
+  }
+
   /**
    * Get the static html used for the editor webviews.
    */
   private getHtmlForWebview(document: vscode.TextDocument): string {
     const dash = JSON.parse(document.getText());
     const uid: string = dash.uid;
+    const theme = this.getTheme();
+
     let view = GrafanaEditorProvider.webviewContent.replaceAll(
       "${filename}",
       document.uri.fsPath,
     );
     view = view.replaceAll("${port}", port.toString());
     view = view.replaceAll("${uid}", uid);
+    view = view.replaceAll("${theme}", theme);
     return view;
   }
 }


### PR DESCRIPTION
Currently, the theme of Grafana is independent of the theme of VSCode. Apart from being
disconcerting, this also causes problems on the error page where we cannot style the
page, because we don't know the theme in use.

This PR adds theming, so that Grafana will, by default, follow the theme of VSCode. It
will add options to configure the chosen theme into the extension settings.﻿
