### PR TITLE
Use correct method to return an HTTP response in proxy server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ export async function startServer(secrets: vscode.SecretStorage, extensionPath: 
     const errorFile = path.join(extensionPath, "public/error.html");
     let content = fs.readFileSync(errorFile, "utf-8");
     content = content.replaceAll("${error}", message);
-    res.write(content);
+    res.send(content);
   };
 
   /*
@@ -82,7 +82,7 @@ export async function startServer(secrets: vscode.SecretStorage, extensionPath: 
           'User-Agent': util.getUserAgent(),
         },
       });
-      res.write(resp.data);
+      res.send(resp.data);
     } catch (e) {
       let msg = "";
       if (URL === "") {


### PR DESCRIPTION
Fixes #86 

I could reproduce the issue locally and noticed that the HTTP call made by the proxy to get the dashboard page from Grafana Cloud was hanging (the HTML was fetched and served, but the HTTP connection didn't close).

I noticed that we used the `write()` function to send the response to the client, while the [Express documentation](https://expressjs.com/en/api.html#res.send) mentions the `send()` function. Using it seems to solve the issue.