### PR TITLE
Support displaying/adding library panels in dashboards

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -187,6 +187,7 @@ export async function startServer(secrets: vscode.SecretStorage, extensionPath: 
     "/public/*",
     "/api/datasources/proxy/*",
     "/api/datasources/*",
+    "/api/library-elements*",
     "/api/plugins/*",
     "/avatar/*",
   ];
@@ -222,6 +223,8 @@ export async function startServer(secrets: vscode.SecretStorage, extensionPath: 
       data: { groups: [] },
     },
     "/api/folders": [],
+    "/api/ruler/grafana/api/v1/rules": {},
+    "/api/recording-rules": [],
     "/api/recording-rules/writer": {
       "id": "cojWep7Vz",
       "data_source_uid": "grafanacloud-prom",


### PR DESCRIPTION
This PR adds support for displaying or adding library panels in dashboards being previewed via the extension.

Note: these panels still can not be created or updated from within the extension (on purpose, since we want to avoid changing the state of the Grafana instance being used by it)

Closes #79