### PR TITLE
Register grafana-vs-code-extension into the software catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: grafana-vs-code-extension
+  title: VS Code Extension for Grafana
+  annotations:
+    github.com/project-slug: grafana/grafana-vs-code-extension
+  links:
+    - title: Slack Channel
+      url: https://raintank-corp.slack.com/archives/C018SLDD5MW
+spec:
+  type: tool
+  owner: group:default/platform-monitoring
+  lifecycle: production


### PR DESCRIPTION
This PR adds the necessary files to declare this repo into the software catalog.