### PR TITLE
Github: Update linter and dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@270f8b2a010f03386d4dcd192eb89535df7b674b #v0.13.7
+        uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0
         with:
           enable-cache: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
   pull_request: ~
+  push:
+    branches:
+      - main
 
 jobs:
   linters:
@@ -9,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
+        uses: jetify-com/devbox-install-action@270f8b2a010f03386d4dcd192eb89535df7b674b #v0.13.7
         with:
           enable-cache: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0

--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Get changed dashboards
         id: changed-files

--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get changed dashboards
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@bab30c2299617f6615ec02a68b9a40d10bd21366 #v41.0.5
         with:
           files: dashboards/**.json
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@270f8b2a010f03386d4dcd192eb89535df7b674b #v0.13.7
+        uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0
         with:
           enable-cache: 'true'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,9 @@ permissions:
 name: Publish Extension
 jobs:
   publish:
-    needs: lint
-
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@a03caf5813591bc882139eba6ae947930a83a427 #v0.11.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,25 +10,6 @@ permissions:
 
 name: Publish Extension
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
-        with:
-          enable-cache: 'true'
-
-      - name: Install vendors
-        run: devbox run yarn install --frozen-lockfile
-
-      - name: Compile codebase
-        run: devbox run yarn run compile
-
-      - name: Run linters
-        run: devbox run yarn run lint
-
   publish:
     needs: lint
 
@@ -37,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.11.0
+        uses: jetify-com/devbox-install-action@270f8b2a010f03386d4dcd192eb89535df7b674b #v0.13.7
         with:
           enable-cache: 'true'
 
@@ -62,7 +43,7 @@ jobs:
         run: devbox run vsce publish --pat ${{ env.VS_MARKETPLACE_TOKEN }} --packagePath grafana-vscode.vsix
 
       - name: Create GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 #v1.14.0
         with:
           allowUpdates: true
           artifacts: "grafana-vscode.vsix"


### PR DESCRIPTION
It updates versions with SHA and apply linter on pull request and merge to main. It removes the linter check in publishing.